### PR TITLE
feat: add protocol fees collected by Balancer Vault

### DIFF
--- a/data/adapters/balancer.ts
+++ b/data/adapters/balancer.ts
@@ -2,14 +2,16 @@ import { OrganizationData } from '../types'
 import { getPortfolio } from '../utils/zerion'
 
 const ecosystemFund = '0xb618F903ad1d00d6F7b92f5b0954DcdC056fC533';
+const protocolFeeCollector = '0xce88686553686DA562CE7Cea497CE749DA109f9F';
 
 export async function getBalancerData(): Promise<OrganizationData> {
   const ecosystemFundTreasury = await getPortfolio(ecosystemFund)
+  const protocolFeeCollectorTreasury = await getPortfolio(protocolFeeCollector)
 
   return {
     id: 'balancer',
     name: 'Balancer',
     category: 'l1',
-    treasury: ecosystemFundTreasury,
+    treasury: ecosystemFundTreasury + protocolFeeCollectorTreasury,
   };
 }


### PR DESCRIPTION
This PR adds tracking for the `protocolFeeCollector` contract for Balancer V2 which receives the protocol-owned fraction of swap fees. This funds are under the control of Balancer governance.

This fraction is currently set to zero so it's not expected show any difference just yet.