### PR TITLE
Add support for filtering native assets

### DIFF
--- a/components/DetailsCard.tsx
+++ b/components/DetailsCard.tsx
@@ -18,10 +18,11 @@ interface DetailsCardProps {
     };
     metadata: any;
   };
+  hideNative: boolean
 }
 
-const DetailsCard: React.FC<DetailsCardProps> = ({ protocol }) => {
-  const { total, sections } = portfolioToSections(protocol.results.currentTreasuryPortfolio)
+const DetailsCard: React.FC<DetailsCardProps> = ({ protocol, hideNative }) => {
+  const { total, sections } = portfolioToSections(protocol.results.currentTreasuryPortfolio, hideNative ? {native: false} : {})
 
   return (
     <div className="details-card">

--- a/components/DetailsCard.tsx
+++ b/components/DetailsCard.tsx
@@ -4,9 +4,20 @@ import Attribute from './Attribute';
 import Button from './Button';
 import TreasuryBar from './TreasuryBar'
 import { portfolioToSections } from 'utils'
+import { PortfolioItem } from 'data/adapters/types';
 
 interface DetailsCardProps {
-  protocol: any;
+  protocol: {
+    id: string;
+    name: string;
+    results: {
+      currentTreasuryUSD: number;
+      currentLiquidTreasuryUSD: number;
+      currentTreasuryPortfolio: PortfolioItem[];
+      recentProposals: any[];
+    };
+    metadata: any;
+  };
 }
 
 const DetailsCard: React.FC<DetailsCardProps> = ({ protocol }) => {

--- a/components/DetailsCard.tsx
+++ b/components/DetailsCard.tsx
@@ -18,11 +18,11 @@ interface DetailsCardProps {
     };
     metadata: any;
   };
-  hideNative: boolean
+  showNative: boolean
 }
 
-const DetailsCard: React.FC<DetailsCardProps> = ({ protocol, hideNative }) => {
-  const { total, sections } = portfolioToSections(protocol.results.currentTreasuryPortfolio, hideNative ? {native: false} : {})
+const DetailsCard: React.FC<DetailsCardProps> = ({ protocol, showNative }) => {
+  const { total, sections } = portfolioToSections(protocol.results.currentTreasuryPortfolio, showNative ? {} : { native: false })
 
   return (
     <div className="details-card">

--- a/components/List.tsx
+++ b/components/List.tsx
@@ -15,15 +15,15 @@ interface ListProps {
     };
     metadata: any;
   }[];
-  hideNative: boolean;
+  showNative: boolean;
 }
 
 const sortTreasury = (a: any, b: any, includeNative: boolean, includeVesting: boolean) => filteredTreasuryValue(b, includeNative, includeVesting) - filteredTreasuryValue(a, includeNative, includeVesting)
 
-const List: React.FC<ListProps> = ({ data, hideNative }) => {
+const List: React.FC<ListProps> = ({ data, showNative }) => {
   const [sort, setSort] = useState('total');
 
-  const sortedData = useMemo(() => data.sort((a, b) => sortTreasury(a,b, !hideNative, sort === 'total')), [data, hideNative, sort]);
+  const sortedData = useMemo(() => data.sort((a, b) => sortTreasury(a,b, showNative, sort === 'total')), [data, showNative, sort]);
 
   return (
     <div className="list">
@@ -38,7 +38,7 @@ const List: React.FC<ListProps> = ({ data, hideNative }) => {
       </div>
 
       {sortedData.map((protocol) => (
-        <Row protocol={protocol} key={protocol.id} hideNative={hideNative} />
+        <Row protocol={protocol} key={protocol.id} showNative={showNative} />
       ))}
 
       <style jsx>{`

--- a/components/List.tsx
+++ b/components/List.tsx
@@ -1,8 +1,19 @@
 import React, { useState } from 'react';
+import { PortfolioItem } from 'data/adapters/types';
 import Row from './Row';
 
 interface ListProps {
-  data: any[];
+  data: {
+    id: string;
+    name: string;
+    results: {
+      currentTreasuryUSD: number;
+      currentLiquidTreasuryUSD: number;
+      currentTreasuryPortfolio: PortfolioItem[];
+      recentProposals: any[];
+    };
+    metadata: any;
+  }[];
 }
 
 const sortTotal = (a: any, b: any) => b.results.currentTreasuryUSD - a.results.currentTreasuryUSD
@@ -24,7 +35,7 @@ const List: React.FC<ListProps> = ({ data }) => {
         </div>
       </div>
 
-      {sortedData.map((protocol: any) => (
+      {sortedData.map((protocol) => (
         <Row protocol={protocol} key={protocol.id} />
       ))}
 

--- a/components/List.tsx
+++ b/components/List.tsx
@@ -1,6 +1,6 @@
 import { PortfolioItem } from 'data/adapters/types';
 import React, { useMemo, useState } from 'react';
-import { filteredPortfolioValue } from 'utils';
+import { filteredTreasuryValue } from 'utils';
 import Row from './Row';
 
 interface ListProps {
@@ -18,16 +18,12 @@ interface ListProps {
   hideNative: boolean;
 }
 
-const totalTreasury = (protocol: any, hideNative: boolean) => hideNative ? protocol.results.currentTreasuryUSD - filteredPortfolioValue(protocol.results.currentTreasuryPortfolio, { native: true }) : protocol.results.currentTreasuryUSD
-const totalLiquid = (protocol: any, hideNative: boolean) => hideNative ? protocol.results.currentTreasuryUSD - filteredPortfolioValue(protocol.results.currentTreasuryPortfolio, { native: true, vesting: false }) : protocol.results.currentLiquidTreasuryUSD
-
-const sortTotal = (a: any, b: any, hideNative: boolean) => totalTreasury(b, hideNative) - totalTreasury(a, hideNative)
-const sortLiquid = (a: any, b: any, hideNative: boolean) => totalLiquid(b, hideNative) - totalLiquid(a, hideNative)
+const sortTreasury = (a: any, b: any, includeNative: boolean, includeVesting: boolean) => filteredTreasuryValue(b, includeNative, includeVesting) - filteredTreasuryValue(a, includeNative, includeVesting)
 
 const List: React.FC<ListProps> = ({ data, hideNative }) => {
   const [sort, setSort] = useState('total');
 
-  const sortedData = useMemo(() => data.sort((a, b) => sort === 'total' ? sortTotal(a, b, hideNative) : sortLiquid(a, b, hideNative)), [data, hideNative]);
+  const sortedData = useMemo(() => data.sort((a, b) => sortTreasury(a,b, !hideNative, sort === 'total')), [data, hideNative, sort]);
 
   return (
     <div className="list">

--- a/components/Row.tsx
+++ b/components/Row.tsx
@@ -4,7 +4,7 @@ import ReactGA from 'react-ga4';
 import { ChevronDown, ChevronUp } from 'react-feather';
 import DetailsCard from './DetailsCard';
 import RowName from './RowName';
-import { filteredPortfolioValue } from 'utils';
+import { filteredTreasuryValue } from 'utils';
 import { PortfolioItem } from 'data/adapters/types';
 
 interface RowProps {
@@ -31,12 +31,8 @@ const Row: React.FC<RowProps> = ({ protocol, hideNative }) => {
 
   // const isApp = protocol.category !== 'l1' && protocol.category !== 'l2';
 
-  const currentTreasury = hideNative
-    ? protocol.results.currentTreasuryUSD - filteredPortfolioValue(protocol.results.currentTreasuryPortfolio, { native: true })
-    : protocol.results.currentTreasuryUSD
-  const currentLiquidTreasury = hideNative
-    ? protocol.results.currentLiquidTreasuryUSD - filteredPortfolioValue(protocol.results.currentTreasuryPortfolio, { native: true, vesting: false })
-    : protocol.results.currentLiquidTreasuryUSD
+  const currentTreasury = filteredTreasuryValue(protocol, !hideNative, true)
+  const currentLiquidTreasury = filteredTreasuryValue(protocol, !hideNative, false)
 
   return (
     <Fragment>

--- a/components/Row.tsx
+++ b/components/Row.tsx
@@ -4,9 +4,20 @@ import ReactGA from 'react-ga4';
 import { ChevronDown, ChevronUp } from 'react-feather';
 import DetailsCard from './DetailsCard';
 import RowName from './RowName';
+import { PortfolioItem } from 'data/adapters/types';
 
 interface RowProps {
-  protocol: any;
+  protocol: {
+    id: string;
+    name: string;
+    results: {
+      currentTreasuryUSD: number;
+      currentLiquidTreasuryUSD: number;
+      currentTreasuryPortfolio: PortfolioItem[];
+      recentProposals: any[];
+    };
+    metadata: any;
+  };
 }
 
 const toggle = (isOpen: boolean) => !isOpen;

--- a/components/Row.tsx
+++ b/components/Row.tsx
@@ -4,6 +4,7 @@ import ReactGA from 'react-ga4';
 import { ChevronDown, ChevronUp } from 'react-feather';
 import DetailsCard from './DetailsCard';
 import RowName from './RowName';
+import { filteredPortfolioValue } from 'utils';
 import { PortfolioItem } from 'data/adapters/types';
 
 interface RowProps {
@@ -18,16 +19,24 @@ interface RowProps {
     };
     metadata: any;
   };
+  hideNative: boolean
 }
 
 const toggle = (isOpen: boolean) => !isOpen;
 
 const cardHeight = 600;
 
-const Row: React.FC<RowProps> = ({ protocol }) => {
+const Row: React.FC<RowProps> = ({ protocol, hideNative }) => {
   const [open, setOpen] = useState(false);
 
   // const isApp = protocol.category !== 'l1' && protocol.category !== 'l2';
+
+  const currentTreasury = hideNative
+    ? protocol.results.currentTreasuryUSD - filteredPortfolioValue(protocol.results.currentTreasuryPortfolio, { native: true })
+    : protocol.results.currentTreasuryUSD
+  const currentLiquidTreasury = hideNative
+    ? protocol.results.currentLiquidTreasuryUSD - filteredPortfolioValue(protocol.results.currentTreasuryPortfolio, { native: true, vesting: false })
+    : protocol.results.currentLiquidTreasuryUSD
 
   return (
     <Fragment>
@@ -53,7 +62,7 @@ const Row: React.FC<RowProps> = ({ protocol }) => {
           subtitle={protocol.metadata.subtitle}
         />
         <div className="amount">
-          {protocol.results.currentTreasuryUSD?.toLocaleString('en-US', {
+          {currentTreasury?.toLocaleString('en-US', {
             style: 'currency',
             currency: 'USD',
             maximumFractionDigits: 0,
@@ -61,7 +70,7 @@ const Row: React.FC<RowProps> = ({ protocol }) => {
           })}
         </div>
         <div className="amount">
-          {protocol.results.currentLiquidTreasuryUSD?.toLocaleString('en-US', {
+          {currentLiquidTreasury?.toLocaleString('en-US', {
             style: 'currency',
             currency: 'USD',
             maximumFractionDigits: 0,
@@ -73,7 +82,7 @@ const Row: React.FC<RowProps> = ({ protocol }) => {
 
       <CSSTransition in={open} timeout={500} unmountOnExit>
         <div className="details-container">
-          <DetailsCard protocol={protocol} />
+          <DetailsCard protocol={protocol} hideNative={hideNative} />
         </div>
       </CSSTransition>
       <style jsx>{`

--- a/components/Row.tsx
+++ b/components/Row.tsx
@@ -19,20 +19,20 @@ interface RowProps {
     };
     metadata: any;
   };
-  hideNative: boolean
+  showNative: boolean
 }
 
 const toggle = (isOpen: boolean) => !isOpen;
 
 const cardHeight = 600;
 
-const Row: React.FC<RowProps> = ({ protocol, hideNative }) => {
+const Row: React.FC<RowProps> = ({ protocol, showNative }) => {
   const [open, setOpen] = useState(false);
 
   // const isApp = protocol.category !== 'l1' && protocol.category !== 'l2';
 
-  const currentTreasury = filteredTreasuryValue(protocol, !hideNative, true)
-  const currentLiquidTreasury = filteredTreasuryValue(protocol, !hideNative, false)
+  const currentTreasury = filteredTreasuryValue(protocol, showNative, true)
+  const currentLiquidTreasury = filteredTreasuryValue(protocol, showNative, false)
 
   return (
     <Fragment>
@@ -78,7 +78,7 @@ const Row: React.FC<RowProps> = ({ protocol, hideNative }) => {
 
       <CSSTransition in={open} timeout={500} unmountOnExit>
         <div className="details-container">
-          <DetailsCard protocol={protocol} hideNative={hideNative} />
+          <DetailsCard protocol={protocol} showNative={showNative} />
         </div>
       </CSSTransition>
       <style jsx>{`

--- a/components/Toolbar.tsx
+++ b/components/Toolbar.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Share, CheckSquare, Square } from 'react-feather';
+import Button from './Button';
+// import gtc from 'icons/gtc.svg';
+
+// const showGitcoin = false;
+
+// const GTCIcon: React.FC = () => (
+//   <div className="gtc">
+//     <style jsx>{`
+//       .gtc {
+//         background: url('${gtc}');
+//         height: 18px;
+//         width: 18px;
+//         margin-right: 2px;
+//         flex: 0 0 18px;
+//       }
+//     `}</style>
+//   </div>
+// );
+
+interface ToolbarProps {
+  hideNative: boolean;
+  onHideNativeChange: (hideNative: boolean) => void;
+}
+
+const Toolbar: React.FC<ToolbarProps> = ({
+  hideNative,
+  onHideNativeChange,
+}) => {
+
+  return (
+    <div className="toolbar">
+
+      <div className="buttons">
+        {/* {showGitcoin && (
+          <Button
+            Icon={GTCIcon}
+            target="gitcoin"
+            href="https://gitcoin.co/grants/1624/cryptofeesinfo"
+          >
+            Support us on Gitcoin
+          </Button>
+        )} */}
+
+        <Button
+          href={`https://twitter.com/intent/tweet?text=${encodeURI(
+              'OpenOrgs.info'
+            )}&url=${encodeURI(window.location.href)}`}
+            Icon={Share}>
+          Share
+        </Button>
+
+        <Button onClick={() => onHideNativeChange(!hideNative)} Icon={hideNative ? CheckSquare : Square}>
+          Hide Native Assets
+        </Button>
+
+      </div>
+
+      <style jsx>{`
+        .toolbar {
+          display: flex;
+          justify-content: flex-end;
+          align-self: stretch;
+        }
+        .buttons > :global(*) {
+          margin-left: 4px;
+        }
+        .buttons {
+          display: flex;
+          justify-content: flex-end;
+          align-self: stretch;
+        }
+        .label {
+          font-size: 10px;
+          display: flex;
+          max-width: 150px;
+          align-items: center;
+          background: #eeeeee;
+          padding: 2px;
+          border-radius: 4px;
+        }
+        .label span {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .label button {
+          margin-left: 4px;
+          background: transparent;
+          border: none;
+          outline: none;
+          padding: 4px;
+        }
+        .label button:hover {
+          background: #dedede;
+        }
+
+        @media (max-width: 700px) {
+          .toolbar {
+            flex-direction: column-reverse;
+          }
+          .tags {
+            margin-top: 4px;
+          }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default Toolbar;

--- a/components/Toolbar.tsx
+++ b/components/Toolbar.tsx
@@ -20,13 +20,13 @@ import Button from './Button';
 // );
 
 interface ToolbarProps {
-  hideNative: boolean;
-  onHideNativeChange: (hideNative: boolean) => void;
+  showNative: boolean;
+  onShowNativeChange: (showNative: boolean) => void;
 }
 
 const Toolbar: React.FC<ToolbarProps> = ({
-  hideNative,
-  onHideNativeChange,
+  showNative,
+  onShowNativeChange,
 }) => {
 
   return (
@@ -51,8 +51,8 @@ const Toolbar: React.FC<ToolbarProps> = ({
           Share
         </Button>
 
-        <Button onClick={() => onHideNativeChange(!hideNative)} Icon={hideNative ? CheckSquare : Square}>
-          Hide Native Assets
+        <Button onClick={() => onShowNativeChange(!showNative)} Icon={showNative ? CheckSquare : Square}>
+          Show Native Assets
         </Button>
 
       </div>

--- a/components/Toolbar.tsx
+++ b/components/Toolbar.tsx
@@ -67,37 +67,10 @@ const Toolbar: React.FC<ToolbarProps> = ({
           justify-content: flex-end;
           align-self: stretch;
         }
-        .label {
-          font-size: 10px;
-          display: flex;
-          max-width: 150px;
-          align-items: center;
-          background: #eeeeee;
-          padding: 2px;
-          border-radius: 4px;
-        }
-        .label span {
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
-        .label button {
-          margin-left: 4px;
-          background: transparent;
-          border: none;
-          outline: none;
-          padding: 4px;
-        }
-        .label button:hover {
-          background: #dedede;
-        }
 
         @media (max-width: 700px) {
           .toolbar {
             flex-direction: column-reverse;
-          }
-          .tags {
-            margin-top: 4px;
           }
         }
       `}</style>

--- a/components/Toolbar.tsx
+++ b/components/Toolbar.tsx
@@ -43,11 +43,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
           </Button>
         )} */}
 
-        <Button
-          href={`https://twitter.com/intent/tweet?text=${encodeURI(
-              'OpenOrgs.info'
-            )}&url=${encodeURI(window.location.href)}`}
-            Icon={Share}>
+        <Button href={`https://twitter.com/share?ref_src=twsrc%5Etfw`} Icon={Share}>
           Share
         </Button>
 

--- a/data/adapters/aave.ts
+++ b/data/adapters/aave.ts
@@ -3,6 +3,8 @@ import { Context } from '@cryptostats/sdk'
 const ECOSYSTEM_RESERVE = '0x25F2226B597E8F9514B3F68F00f494cF4f286491';
 const revenueCollector = '0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c';
 
+const NATIVE_TOKENS = ['0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9'];
+
 interface PortfolioAsset {
   address: string
   amount: number
@@ -11,6 +13,8 @@ interface PortfolioAsset {
   icon: string
   price: number
   value: number
+  native: boolean
+  vesting: boolean
 }
 
 export async function setup(sdk: Context) {
@@ -61,6 +65,8 @@ export async function setup(sdk: Context) {
           name: token.tokenInfo.name,
           symbol: token.tokenInfo.symbol,
           icon: `https://s3.amazonaws.com/token-icons/${token.tokenInfo.address}.png`,
+          native: NATIVE_TOKENS.includes(token.tokenInfo.address),
+          vesting: false
         })
       }
     }
@@ -81,6 +87,8 @@ export async function setup(sdk: Context) {
             name: token.tokenInfo.name,
             symbol: token.tokenInfo.symbol,
             icon: `https://s3.amazonaws.com/token-icons/${token.tokenInfo.address}.png`,
+            native: NATIVE_TOKENS.includes(token.tokenInfo.address),
+            vesting: false
           })
         }
       }
@@ -102,7 +110,10 @@ export async function setup(sdk: Context) {
       getEcosystemReservePortfolio(),
       getEthplorerPortfolio(revenueCollector),
     ])
-    return [...reservePortfolio, ...collectorPortfolio]
+    return [
+      ...reservePortfolio.map((portfolioItem: any) => ({...portfolioItem, native: NATIVE_TOKENS.includes(portfolioItem.address) })),
+      ...collectorPortfolio
+    ]
   }
 
   const getRecentProposals = async () => {

--- a/data/adapters/bzx.ts
+++ b/data/adapters/bzx.ts
@@ -3,6 +3,8 @@ import { getSnapshotProposals } from './snapshot'
 
 const TREASURY_ADDRESS = '0xfedC4dD5247B93feb41e899A09C44cFaBec29Cbc'
 
+const NATIVE_TOKENS = ['0x56d811088235f11c8920698a204a5010a788f4b3', '0xb72b31907c1c95f3650b64b2469e08edacee5e8f'];
+
 export async function setup(sdk: Context) {
   let treasuryPortfolioPromise: Promise<any> | null
   const getTresuryPortfolio = (): Promise<any> => {
@@ -25,12 +27,16 @@ export async function setup(sdk: Context) {
   }
 
   const getPortfolio = async () => {
-    const portfolio = await getTresuryPortfolio()
+    const { portfolio } = await getTresuryPortfolio()
 
-    const withVesting = portfolio.portfolio.map((item: any) => item.symbol === 'vBZRX' ? {
-        ...item,
-        vesting: true,
-      } : item)
+    const withVesting = portfolio
+      .map((portfolioItem: any) => (
+        {
+          ...portfolioItem,
+          native: NATIVE_TOKENS.includes(portfolioItem.address),
+          vesting: portfolioItem.symbol === 'vBZRX'
+        }
+      ))
 
     return withVesting
   }

--- a/data/adapters/bzx.ts
+++ b/data/adapters/bzx.ts
@@ -7,7 +7,7 @@ const NATIVE_TOKENS = ['0x56d811088235f11c8920698a204a5010a788f4b3', '0xb72b3190
 
 export async function setup(sdk: Context) {
   let treasuryPortfolioPromise: Promise<any> | null
-  const getTresuryPortfolio = (): Promise<any> => {
+  const getTreasuryPortfolio = (): Promise<any> => {
     if (!treasuryPortfolioPromise) {
       treasuryPortfolioPromise = fetch(`https://zerion-api.vercel.app/api/portfolio/${TREASURY_ADDRESS}`)
         .then(req => req.json())
@@ -22,12 +22,12 @@ export async function setup(sdk: Context) {
   }
 
   const getTreasuryInUSD = async () => {
-    const treasury = await getTresuryPortfolio()
+    const treasury = await getTreasuryPortfolio()
     return treasury.totalValue
   }
 
   const getPortfolio = async () => {
-    const { portfolio } = await getTresuryPortfolio()
+    const { portfolio } = await getTreasuryPortfolio()
 
     const withVesting = portfolio
       .map((portfolioItem: any) => (

--- a/data/adapters/dxdao.ts
+++ b/data/adapters/dxdao.ts
@@ -37,6 +37,8 @@ export async function setup(sdk: Context) {
         name: 'USDC',
         symbol: 'USDC',
         icon: `https://s3.amazonaws.com/token-icons/${USDC_TOKEN}.png`,
+        native: false,
+        vesting: false
       },
       {
         address: DXD_TOKEN,
@@ -46,6 +48,8 @@ export async function setup(sdk: Context) {
         name: 'DXdao',
         symbol: 'DXD',
         icon: `https://s3.amazonaws.com/token-icons/${DXD_TOKEN}.png`,
+        native: true,
+        vesting: false
       },
     ]
 

--- a/data/adapters/dxdao.ts
+++ b/data/adapters/dxdao.ts
@@ -71,7 +71,10 @@ export async function setup(sdk: Context) {
       getBondingCurve(),
     ])
 
-    return [...reservePortfolio, ...bondingCurvePortfolio]
+    return [
+      ...reservePortfolio.map((portfolioItem: any) => ({ ...portfolioItem, native: portfolioItem.address === DXD_TOKEN })),
+      ...bondingCurvePortfolio
+    ]
   }
 
   sdk.register({

--- a/data/adapters/dxdao.ts
+++ b/data/adapters/dxdao.ts
@@ -6,7 +6,7 @@ const USDC_TOKEN = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
 
 export async function setup(sdk: Context) {
   let treasuryPortfolioPromise: Promise<any> | null
-  const getTresuryPortfolio = (): Promise<any> => {
+  const getTreasuryPortfolio = (): Promise<any> => {
     if (!treasuryPortfolioPromise) {
       treasuryPortfolioPromise = fetch(`https://zerion-api.vercel.app/api/portfolio/${TREASURY_ADDRESS}`)
         .then(req => req.json())
@@ -58,7 +58,7 @@ export async function setup(sdk: Context) {
 
   const getTreasuryInUSD = async () => {
     const [treasury, { totalValue: bondingCurveVal }] = await Promise.all([
-      getTresuryPortfolio(),
+      getTreasuryPortfolio(),
       getBondingCurve(),
     ])
 
@@ -67,7 +67,7 @@ export async function setup(sdk: Context) {
 
   const getPortfolio = async () => {
     const [{ portfolio: reservePortfolio }, { portfolio: bondingCurvePortfolio }] = await Promise.all([
-      getTresuryPortfolio(),
+      getTreasuryPortfolio(),
       getBondingCurve(),
     ])
 

--- a/data/adapters/makerdao.ts
+++ b/data/adapters/makerdao.ts
@@ -3,6 +3,8 @@ import { Context } from '@cryptostats/sdk'
 const VAT_ADDRESS = '0x35d1b3f3d7966a1dfe207aa4514c12a259a0492b'
 const PAUSE_ADDRESS = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb'
 
+const NATIVE_TOKENS = ['0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2']
+
 const vatABI = [
   'function dai(address holder) external view returns (uint256)',
   'function sin(address holder) external view returns (uint256)',
@@ -51,7 +53,7 @@ export async function setup(sdk: Context) {
     ])
 
     return [
-      ...pausePortfolio.portfolio,
+      ...pausePortfolio.portfolio.map((portfolioItem: any) => ({ ...portfolioItem,  native: NATIVE_TOKENS.includes(portfolioItem.address) })),
       {
         address: '0x6b175474e89094c44da98b954eedeac495271d0f',
         amount: daiSurplus,
@@ -59,7 +61,9 @@ export async function setup(sdk: Context) {
         symbol: 'DAI',
         icon: 'https://s3.amazonaws.com/token-icons/0x6b175474e89094c44da98b954eedeac495271d0f.png',
         price: 1,
-        value: daiSurplus
+        value: daiSurplus,
+        native: false,
+        vesting: false
       },
     ]
   }

--- a/data/adapters/pooltogether.ts
+++ b/data/adapters/pooltogether.ts
@@ -4,6 +4,8 @@ const TREASURY_ADDRESS = '0x42cd8312D2BCe04277dD5161832460e95b24262E'
 const VESTING_ADDRESS = '0x21950E281bDE1714ffd1062ed17c56D4D8de2359'
 const SCUSDC_TOKEN = '0x391a437196c81eea7bbbbd5ed4df6b49de4f5c96'
 
+const NATIVE_TOKENS = ['0x0cec1a9154ff802e7934fc916ed7ca50bde6844e']
+
 export async function setup(sdk: Context) {
   let portfolioCache: { [address: string]: Promise<any> } = {}
   const getPortfolio = (key: string): Promise<any> => {
@@ -52,8 +54,8 @@ export async function setup(sdk: Context) {
     ])
 
     return [
-      ...treasury.portfolio,
-      ...vesting.portfolio.map((portfolioItem: any) => ({ ...portfolioItem, vesting: true })),
+      ...treasury.portfolio.map((portfolioItem: any) => ({ ...portfolioItem,  native: NATIVE_TOKENS.includes(portfolioItem.address) })),
+      ...vesting.portfolio.map((portfolioItem: any) => ({ ...portfolioItem,  native: NATIVE_TOKENS.includes(portfolioItem.address), vesting: true })),
       {
         address: SCUSDC_TOKEN,
         amount: scusdc,
@@ -62,6 +64,8 @@ export async function setup(sdk: Context) {
         name: 'PoolTogether USDC Sponsorship',
         symbol: 'ScUSDC',
         icon: null,
+        native: false,
+        vesting: false
       },
     ]
   }

--- a/data/adapters/simple-treasuries.ts
+++ b/data/adapters/simple-treasuries.ts
@@ -243,7 +243,12 @@ const orgs: Org[] = [
   {
     id: 'olympus',
     addresses: [
-      '0x31F8Cc382c9898b273eff4e0b7626a6987C846E8',
+      '0x31F8Cc382c9898b273eff4e0b7626a6987C846E8', // Olympus Treasury
+      '0x3df5a355457db3a4b5c744b8623a7721bf56df78', // Convex Allocator
+      '0x0316508a1b5abf1CAe42912Dc2C8B9774b682fFC', // Onsen Allocator
+      '0x0e1177e47151Be72e5992E0975000E73Ab5fd9D4', // Aave Allocator
+    ],
+    nativeTokens: [
       '0x34d7d7aaf50ad4944b70b320acb24c95fa2def7c', // OHM-DAI LP
       '0x2dce0dda1c2f98e0f171de8333c3c6fe1bbf4877', // OHM-FRAX LP
       '0xfffae4a0f4ac251f4705717cd24cadccc9f33e06', // OHM-WETH LP

--- a/data/adapters/simple-treasuries.ts
+++ b/data/adapters/simple-treasuries.ts
@@ -6,6 +6,7 @@ interface Org {
   icon?: string
   addresses: string[]
   vestingAddresses?: string[]
+  nativeTokens?: string[]
   iconType?: string
   snapshotId?: string
   governanceSite?: string
@@ -17,6 +18,7 @@ const orgs: Org[] = [
   {
     id: 'alchemix',
     addresses: ['0x8392f6669292fa56123f71949b52d883ae57e225'],
+    nativeTokens: ['0xdbdb4d16eda451d0503b854cf79d55697f90c8df'],
     icon: 'QmSuSUcAvGkxkJ7n5RxnDyqXUchAjXMwTmNioz2xzXVfxo',
     iconType: 'image/jpeg',
     snapshotId: 'alchemixstakers.eth',
@@ -31,6 +33,7 @@ const orgs: Org[] = [
   {
     id: 'api3',
     addresses: ['0xe7aF7c5982e073aC6525a34821fe1B3e8E432099'],
+    nativeTokens: ['0x0b38210ea11411557c13457D4dA7dC6ea731B88a'],
     icon: 'QmVp2hVgfD8sQRFosydPsNAVmttno5tRhun44YiXagNeGX',
     iconType: 'image/jpeg',
     metadata: {
@@ -48,6 +51,7 @@ const orgs: Org[] = [
       '0x8de82c4c968663a0284b01069dde6ef231d0ef9b',
       '0xb65cef03b9b89f99517643226d76e286ee999e77',
     ],
+    nativeTokens: ['0x3472A5A71965499acd81997a54BBA8D852C6E53d'],
     icon: 'QmSraKiNmctuShFEqgGmLVamKuwZC6TFs26R27959ugExn',
     iconType: 'image/png',
     snapshotId: 'badgerdao.eth',
@@ -65,6 +69,7 @@ const orgs: Org[] = [
       '0xb618F903ad1d00d6F7b92f5b0954DcdC056fC533', // ecosystem fund
       '0xce88686553686DA562CE7Cea497CE749DA109f9F', // protocol fee collector
     ],
+    nativeTokens: ['0xba100000625a3754423978a60c9317c58a424e3d'],
     icon: 'Qma9agewDVEhZjnLrY2aWy3ZHvYmUtZ5uXM3tCHZu5eDM2',
     metadata: {
       name: 'Balancer',
@@ -77,6 +82,7 @@ const orgs: Org[] = [
   {
     id: 'barnbridge',
     addresses: ['0x4cAE362D7F227e3d306f70ce4878E245563F3069'],
+    nativeTokens: ['0x0391D2021f89DC339F60Fff84546EA23E337750f'],
     icon: 'QmWD4Eg6AdYmyAb9aSfELP7L4cU2uTFYoejHVsWjerYWZo',
     metadata: {
       name: 'BarnBridge',
@@ -90,6 +96,7 @@ const orgs: Org[] = [
     id: 'compound',
     addresses: ['0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b'],
     vestingAddresses: ['0x2775b1c75658Be0F640272CCb8c72ac986009e38'],
+    nativeTokens: ['0xc00e94cb662c3520282e6f5717214004a7f26888'],
     icon: 'QmZpZsg829EnBxE2MPZykZpAfsxyRsu6EuGbtfTkf2EFNj',
     metadata: {
       name: 'Compound',
@@ -122,6 +129,7 @@ const orgs: Org[] = [
       '0xde21F729137C5Af1b01d73aF1dC21eFfa2B8a0d6', // Grants
     ],
     vestingAddresses: ['0x44aa9c5a034c1499ec27906e2d427b704b567ffe'],
+    nativeTokens: ['0xde30da39c46104798bb5aa3fe8b9e0e1f348163f'],
     icon: 'QmR8nFrnSu7Mby5tdPPdUrTZttaK7L3TVsZheuwZ1KPUCT',
     snapshotId: 'gitcoindao.eth',
     metadata: {
@@ -133,6 +141,7 @@ const orgs: Org[] = [
   {
     id: 'index-coop',
     addresses: ['0x9467cfADC9DE245010dF95Ec6a585A506A8ad5FC'],
+    nativeTokens: ['0x0954906da0Bf32d5479e25f46056d22f08464cab'],
     icon: 'QmRU38pAray7rYt4irRswPAK6E6nxiTiXZ1bAp8fr3CcW2',
     iconType: 'image/png',
     snapshotId: 'index-coop.eth',
@@ -157,6 +166,7 @@ const orgs: Org[] = [
   {
     id: 'lido',
     addresses: ['0x3e40d73eb977dc6a537af587d48316fee66e9c8c'],
+    nativeTokens: ['0x5a98fcbea516cf06857215779fd812ca3bef1b32'],
     icon: 'QmcsGcopqrVyzTLXETtecJuhqxqxbzUvuFMqBd27yFKCMt',
     metadata: {
       name: 'Lido',
@@ -168,6 +178,7 @@ const orgs: Org[] = [
   {
     id: 'linkswap',
     addresses: ['0xE69A81b96FBF5Cb6CAe95d2cE5323Eff2bA0EAE4'],
+    nativeTokens: ['0x28cb7e841ee97947a86B06fA4090C8451f64c0be'],
     icon: 'QmdAhG1qWuW6wEcuW29ZjAvqPz8grSYHsR7HZJLSkqkGQ5',
     snapshotId: 'yflink.eth',
     metadata: {
@@ -194,6 +205,7 @@ const orgs: Org[] = [
       '0xfcf455d6eb48b3289a712c0b3bc3c7ee0b0ee4c6', // Funding subDAO
       '0x67905d3e4fec0c85dce68195f66dc8eb32f59179', // Asset Management subDAO
     ],
+    nativeTokens: ['0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2'],
     icon: 'QmTkxsvMnSPb7A2bPUxA4uJRwJefkyzFgGar5NVxV5UJjr',
     metadata: {
       name: 'mStable',
@@ -206,6 +218,7 @@ const orgs: Org[] = [
   {
     id: 'nexus',
     addresses: ['0x586b9b2F8010b284A0197f392156f1A7Eb5e86e9'],
+    nativeTokens: ['0xd7c49cee7e9188cca6ad8ff264c1da2e69d4cf3b', '0x0d438f3b5175bebc262bf23753c1e53d03432bde'],
     icon: 'QmWA5VaHWMH96mLmoaLKaxKVf86GLUJQVBp6BfaUoLH81g',
     metadata: {
       name: 'Nexus Mutual',
@@ -239,6 +252,7 @@ const orgs: Org[] = [
   {
     id: 'piedao',
     addresses: ['0x3bcf3db69897125aa61496fc8a8b55a5e3f245d5'],
+    nativeTokens: ['0xad32A8e6220741182940c5aBF610bDE99E737b2D'],
     icon: 'QmahuQPfbqJEE9tXZKfubWPviy5wxesdfBbdUXhf8JRcN4',
     snapshotId: 'piedao',
     metadata: {
@@ -250,6 +264,7 @@ const orgs: Org[] = [
   {
     id: 'sushi',
     addresses: ['0xe94b5eec1fa96ceecbd33ef5baa8d00e4493f4f3'],
+    nativeTokens: ['0x6b3595068778dd592e39a122f4f5a5cf09c90fe2', '0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272'],
     icon: 'QmVAko4auvE2NDr8kfnovVqTqujrJ69YrUZQFPZeREMWk5',
     snapshotId: 'sushigov.eth',
     metadata: {
@@ -266,6 +281,7 @@ const orgs: Org[] = [
       '0x86626E1BbBd0ce95ED52e0C5E19f371a6640B591', // grants DAO
       '0x99f4176ee457afedffcb1839c7ab7a030a5e4a92', // treasury council
     ],
+    nativeTokens: ['0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f'],
     icon: 'QmYPqFXTqYcynD5hT9sZbsoPZXbvjSfL7WWQPL7EwYAyE5',
     metadata: {
       name: 'Synthetix',
@@ -279,6 +295,7 @@ const orgs: Org[] = [
     id: 'tornado',
     addresses: ['0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce'],
     vestingAddresses: ['0x179f48C78f57A3A78f0608cC9197B8972921d1D2'],
+    nativeTokens: ['0x77777feddddffc19ff86db637967013e6c6a116c'],
     icon: 'QmeUzPPCdpqEYArWyMdUVZJk4GUmuR4TAkK6U4eb9vZDPa',
     metadata: {
       name: 'Tornado Cash',
@@ -299,6 +316,7 @@ const orgs: Org[] = [
       '0x4b4e140d1f131fdad6fb59c13af796fd194e4135',
       '0x3d30b1ab88d487b0f3061f40de76845bec3f1e94',
     ],
+    nativeTokens: ["0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"],
     icon: 'QmPXoiG66a9gCDX1NX51crWV7UAijoFd5wycHrfRKM6Y1n',
     metadata: {
       name: 'Uniswap',
@@ -337,6 +355,7 @@ const orgs: Org[] = [
       '0x205cc7463267861002b27021c7108bc230603d0f', // stakedDPI
       '0xd67c05523d8ec1c60760fd017ef006b9f6e496d0', // randomHoldings
     ],
+    nativeTokens: ['0x0AaCfbeC6a24756c20D41914F2caba817C0d8521'],
     icon: 'QmcPjtA1Q9QhnAeruXkrsYU3HZ5b8sm3eU78VUjHDXhior',
     iconType: 'image/png',
     snapshotId: 'yam',
@@ -354,6 +373,7 @@ const orgs: Org[] = [
       '0x93A62dA5a14C80f265DAbC077fCEE437B1a0Efde', // treasury.ychad.eth
       '0xd42e1cb8b98382df7db43e0f09dfe57365659d16', // DSProxy
     ],
+    nativeTokens: ['0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e'],
     icon: 'QmYGdvDA6jM5AV1yBvQKUAz74wqGeBUwVohBWEgbwqXpjk',
     snapshotId: 'yearn',
     metadata: {
@@ -387,15 +407,17 @@ export async function setup(sdk: Context) {
     return portfolio.totalValue
   }
 
-  const createPortfolioLoader = (addresses: string[], vestingAddresses?: string[]) => async () => {
+  const createPortfolioLoader = (addresses: string[], vestingAddresses?: string[], nativeTokens: string[] = []) => async () => {
     const [{ portfolio }, { portfolio: vestingPortfolio }] = await Promise.all([
       getPortfolio(addresses),
       vestingAddresses ? getPortfolio(vestingAddresses) : { portfolio: [] },
     ])
 
+    const nativeTokensLower = nativeTokens.map(addr => addr.toLowerCase())
     return [
-      ...portfolio,
-      ...vestingPortfolio.map((portfolioItem: any) => ({ ...portfolioItem, vesting: true }))
+      ...portfolio.map((portfolioItem: any) => ({ ...portfolioItem, native: nativeTokensLower.includes(portfolioItem.address) })),
+      ...vestingPortfolio
+          .map((portfolioItem: any) => ({ ...portfolioItem, native: nativeTokensLower.includes(portfolioItem.address), vesting: true }))
     ]
   }
 
@@ -412,7 +434,7 @@ export async function setup(sdk: Context) {
       queries: {
         currentTreasuryUSD: createTreasuryLoader([...org.addresses, ...(org.vestingAddresses || [])]),
         currentLiquidTreasuryUSD: createTreasuryLoader(org.addresses),
-        currentTreasuryPortfolio: createPortfolioLoader(org.addresses, org.vestingAddresses),
+        currentTreasuryPortfolio: createPortfolioLoader(org.addresses, org.vestingAddresses, org.nativeTokens),
         recentProposals,
       },
       metadata: {

--- a/data/adapters/simple-treasuries.ts
+++ b/data/adapters/simple-treasuries.ts
@@ -114,6 +114,7 @@ const orgs: Org[] = [
       '0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7', // Timelock
     ],
     vestingAddresses: ['0xd7A029Db2585553978190dB5E85eC724Aa4dF23f'],
+    nativeTokens: ['0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72'],
     icon: 'QmVmFQeYcLjeEm2fFhyyS762KytMQQhwdEXyGXAid1Rf8B',
     snapshotId: 'ens.eth',
     metadata: {

--- a/data/adapters/simple-treasuries.ts
+++ b/data/adapters/simple-treasuries.ts
@@ -241,7 +241,13 @@ const orgs: Org[] = [
   },
   {
     id: 'olympus',
-    addresses: ['0x31F8Cc382c9898b273eff4e0b7626a6987C846E8'],
+    addresses: [
+      '0x31F8Cc382c9898b273eff4e0b7626a6987C846E8',
+      '0x34d7d7aaf50ad4944b70b320acb24c95fa2def7c', // OHM-DAI LP
+      '0x2dce0dda1c2f98e0f171de8333c3c6fe1bbf4877', // OHM-FRAX LP
+      '0xfffae4a0f4ac251f4705717cd24cadccc9f33e06', // OHM-WETH LP
+      '0xfdf12d1f85b5082877a6e070524f50f6c84faa6b', // OHM-LUSD LP
+    ],
     icon: 'QmbtqUKno2FATf4RFPXAvWCamYrRT6UAKurKiNCuMCJw1J',
     snapshotId: 'olympusdao.eth',
     metadata: {
@@ -281,7 +287,10 @@ const orgs: Org[] = [
       '0x86626E1BbBd0ce95ED52e0C5E19f371a6640B591', // grants DAO
       '0x99f4176ee457afedffcb1839c7ab7a030a5e4a92', // treasury council
     ],
-    nativeTokens: ['0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f'],
+    nativeTokens: [
+      '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f', // SNX
+      '0x072f14b85add63488ddad88f855fda4a99d6ac9b' // SNX-ETH LP
+    ],
     icon: 'QmYPqFXTqYcynD5hT9sZbsoPZXbvjSfL7WWQPL7EwYAyE5',
     metadata: {
       name: 'Synthetix',

--- a/data/adapters/types.ts
+++ b/data/adapters/types.ts
@@ -1,0 +1,9 @@
+export interface PortfolioItem {
+    address: string;
+    amount: number;
+    name: string;
+    symbol: string;
+    icon: string;
+    price: number;
+    value: number;
+}

--- a/data/adapters/types.ts
+++ b/data/adapters/types.ts
@@ -6,4 +6,6 @@ export interface PortfolioItem {
     icon: string;
     price: number;
     value: number;
+    native: boolean,
+    vesting: boolean,
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,7 @@ import 'data/adapters'
 import sdk from 'data/sdk'
 import List from 'components/List'
 import SocialTags from 'components/SocialTags'
+import Toolbar from 'components/Toolbar'
 import { PortfolioItem } from 'data/adapters/types'
 
 interface HomeProps {
@@ -35,16 +36,10 @@ export const Home: NextPage<HomeProps> = ({ data }) => {
           What's on their balance sheets?
         </p>
 
-        <div>
-          <a
-            href="https://twitter.com/share?ref_src=twsrc%5Etfw"
-            className="twitter-share-button"
-            data-show-count="true"
-          >
-            Tweet
-          </a>
-          <script async src="https://platform.twitter.com/widgets.js"></script>
-        </div>
+        <Toolbar
+          hideNative={hideNative}
+          onHideNativeChange={setHideNative}
+        />
 
         <List data={data} hideNative={hideNative} />
       </main>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,9 +4,20 @@ import 'data/adapters'
 import sdk from 'data/sdk'
 import List from 'components/List'
 import SocialTags from 'components/SocialTags'
+import { PortfolioItem } from 'data/adapters/types'
 
 interface HomeProps {
-  data: any[]
+  data: {
+    id: string;
+    name: string;
+    results: {
+      currentTreasuryUSD: number;
+      currentLiquidTreasuryUSD: number;
+      currentTreasuryPortfolio: PortfolioItem[];
+      recentProposals: any[];
+    };
+    metadata: any;
+  }[]
 }
 
 export const Home: NextPage<HomeProps> = ({ data }) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,7 +22,7 @@ interface HomeProps {
 }
 
 export const Home: NextPage<HomeProps> = ({ data }) => {
-  const [hideNative, setHideNative] = useState(false);
+  const [showNative, setshowNative] = useState(true);
 
   return (
     <div className="container">
@@ -37,11 +37,11 @@ export const Home: NextPage<HomeProps> = ({ data }) => {
         </p>
 
         <Toolbar
-          hideNative={hideNative}
-          onHideNativeChange={setHideNative}
+          showNative={showNative}
+          onShowNativeChange={setshowNative}
         />
 
-        <List data={data} hideNative={hideNative} />
+        <List data={data} showNative={showNative} />
       </main>
 
       <style jsx>{`

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { NextPage, GetStaticProps } from 'next'
 import 'data/adapters'
 import sdk from 'data/sdk'
@@ -21,6 +21,8 @@ interface HomeProps {
 }
 
 export const Home: NextPage<HomeProps> = ({ data }) => {
+  const [hideNative, setHideNative] = useState(false);
+
   return (
     <div className="container">
       <SocialTags />
@@ -44,7 +46,7 @@ export const Home: NextPage<HomeProps> = ({ data }) => {
           <script async src="https://platform.twitter.com/widgets.js"></script>
         </div>
 
-        <List data={data} />
+        <List data={data} hideNative={hideNative} />
       </main>
 
       <style jsx>{`

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -50,5 +50,5 @@ export function filteredPortfolioValue(portfolio: PortfolioItem[], filters: {nat
       if (filters.vesting !== undefined && item.vesting != filters.vesting) return false;
       return true
     })
-    .reduce((totalNativeValue: number, item: any) => totalNativeValue + item.value, 0)
+    .reduce((totalValue: number, item: any) => totalValue + item.value, 0)
 }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -39,7 +39,7 @@ export function filteredTreasuryValue(protocol: any, native: boolean, vesting: b
   const {currentTreasuryUSD, currentLiquidTreasuryUSD, currentTreasuryPortfolio } = protocol.results
   if (native) return vesting ? currentTreasuryUSD : currentLiquidTreasuryUSD
   return vesting
-    ? currentTreasuryUSD - filteredPortfolioValue(currentTreasuryPortfolio, { native: true, vesting: true })
+    ? currentTreasuryUSD - filteredPortfolioValue(currentTreasuryPortfolio, { native: true })
     : currentLiquidTreasuryUSD - filteredPortfolioValue(currentTreasuryPortfolio, { native: true, vesting: false })
 }
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -35,6 +35,14 @@ export function portfolioToSections(portfolio: PortfolioItem[], filters: {native
   return { total, sections }
 }
 
+export function filteredTreasuryValue(protocol: any, native: boolean, vesting: boolean): number {
+  const {currentTreasuryUSD, currentLiquidTreasuryUSD, currentTreasuryPortfolio } = protocol.results
+  if (native) return vesting ? currentTreasuryUSD : currentLiquidTreasuryUSD
+  return vesting
+    ? currentTreasuryUSD - filteredPortfolioValue(currentTreasuryPortfolio, { native: true, vesting: true })
+    : currentLiquidTreasuryUSD - filteredPortfolioValue(currentTreasuryPortfolio, { native: true, vesting: false })
+}
+
 export function filteredPortfolioValue(portfolio: PortfolioItem[], filters: {native?: boolean, vesting?: boolean}): number {
   return portfolio
     .filter(item => {

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -5,6 +5,11 @@ export function portfolioToSections(portfolio: PortfolioItem[], filters: {native
   let total = 0
   let other = 0
   const sections: Section[] = portfolio
+    .filter(item => {
+      if (filters.native !== undefined && item.native != filters.native) return false;
+      if (filters.vesting !== undefined && item.vesting != filters.vesting) return false;
+      return true
+    })
     .map((item) => {
       total += item.value
       return {
@@ -28,4 +33,14 @@ export function portfolioToSections(portfolio: PortfolioItem[], filters: {native
   }
 
   return { total, sections }
+}
+
+export function filteredPortfolioValue(portfolio: PortfolioItem[], filters: {native?: boolean, vesting?: boolean}): number {
+  return portfolio
+    .filter(item => {
+      if (filters.native !== undefined && item.native != filters.native) return false;
+      if (filters.vesting !== undefined && item.vesting != filters.vesting) return false;
+      return true
+    })
+    .reduce((totalNativeValue: number, item: any) => totalNativeValue + item.value, 0)
 }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,10 +1,11 @@
 import { Section } from 'components/TreasuryBar'
+import { PortfolioItem } from 'data/adapters/types';
 
-export function portfolioToSections(portfolio: any[]) {
+export function portfolioToSections(portfolio: PortfolioItem[], filters: {native?: boolean, vesting?: boolean}) {
   let total = 0
   let other = 0
   const sections: Section[] = portfolio
-    .map((item: any) => {
+    .map((item) => {
       total += item.value
       return {
         amount: item.value,
@@ -14,14 +15,14 @@ export function portfolioToSections(portfolio: any[]) {
         vesting: item.vesting,
       }
     })
-    .filter((item: any) => {
+    .filter((item) => {
       if (item.amount < total * 0.02) {
         other += item.amount
         return false
       }
       return true
     })
-    .sort((a: any, b: any) => b.amount - a.amount)
+    .sort((a, b) => b.amount - a.amount)
   if (other > 0) {
     sections.push({ amount: other, name: 'Other' })
   }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,7 +1,10 @@
 import { Section } from 'components/TreasuryBar'
 import { PortfolioItem } from 'data/adapters/types';
 
-export function portfolioToSections(portfolio: PortfolioItem[], filters: {native?: boolean, vesting?: boolean}) {
+export function portfolioToSections(
+  portfolio: PortfolioItem[],
+  filters: {native?: boolean, vesting?: boolean} = {}
+) {
   let total = 0
   let other = 0
   const sections: Section[] = portfolio


### PR DESCRIPTION
This PR adds support for filtering out native assets for each organisation.

Each org has an array of addresses which are used to set a `native` flag on each of its portfolio items. To filter these out from the global treasury value, I've added a couple of functions to the utils folder which allow us to subtract off the value of any native assets.